### PR TITLE
ok_esc toolbar: choose_select_label option (complements draw_cells {} sel

### DIFF
--- a/Eludia/Presentation.pm
+++ b/Eludia/Presentation.pm
@@ -1229,7 +1229,11 @@ sub draw_ok_esc_toolbar {
 		{
 			preset => 'choose',
 			label => $options -> {label_choose},
-			href  => js_set_select_option ('', $data),
+			href  => js_set_select_option ('', {
+				id       => $data -> {id}, 
+				label    => $options -> {choose_select_label} || $data -> {label},
+				question => $data -> {question},
+			}),
 			off   => (!$_REQUEST {__read_only} || !$_REQUEST {select}),
 		},
 		@{$options -> {additional_buttons}},


### PR DESCRIPTION
ok_esc toolbar: choose_select_label option (complements draw_cells {} select_label option)

ситуация: select-поле со справочником, 
выбираем не из списка а по-одиночке, 
выбираемый объект имеет кастомную подпись, которая должна попасть в вызывающее select-поле
