### PR TITLE
множетсвенный выбор файлов: кнопка очистки файлового поля иногда удаляет сразу два поля

### DIFF
--- a/Eludia/Presentation/Skins/TurboMilk.pm
+++ b/Eludia/Presentation/Skins/TurboMilk.pm
@@ -845,8 +845,6 @@ EOH
 		
 			setCursor ();
 
-			file_field_$options->{name}_cnt --;
-
 			\$(id_file_field).empty();
 		
 		}


### PR DESCRIPTION
надо удалить файл в середине, а потом добавить в конец новый 

ссылка кнопки очистки ведет на file_file_field_remove_attaches(id),  
среди полученных полей будет два с одинаковым id
