### PR TITLE
check_peer_server generates fake users with fake = -128

### DIFF
--- a/Eludia/Content/Peering.pm
+++ b/Eludia/Content/Peering.pm
@@ -36,7 +36,7 @@ sub check_peer_server {
 		
 		sql_do_insert ($conf->{systables}->{users}, {
 			fake        => -128,
-			peer_id     => $user -> {id},
+			peer_id     => 0 + $user -> {id},
 			peer_server => $peer_server,
 		});
 		


### PR DESCRIPTION
check_peer_server генерирует, не останавливаясь, пользователей с fake = -128

проблема тут

``` perl
sub check_peer_server {
    #...
    my $id_user = 

        sql_select_scalar ("SELECT id FROM $conf->{systables}->{users} WHERE peer_id = ? AND peer_server = ?", 0 + $user -> {id}, $peer_server) ||

        sql_do_insert ($conf->{systables}->{users}, {
            fake        => -128,
            peer_id     =>  $user -> {id},
            peer_server => $peer_server,
        });
```

При определенных условиях вставляется пользователь с peer_id => undef, 
то есть peer_id у него будет NULL.
Из-за этого при следующем вызове check_peer_server пользователь вставится повторно
Коммит правит это поведение
