### PR TITLE
sql() wipes OR filter values afer first call

### DIFF
--- a/Eludia/SQL/TheSqlFunction.pm
+++ b/Eludia/SQL/TheSqlFunction.pm
@@ -210,7 +210,8 @@ sub _sql_filters {
 			next;
 		}
 		
-		my $was_array = ref $values eq ARRAY or $values = [$values];
+		my $was_array = ref $values eq ARRAY;
+		$values = $was_array? Storable::dclone ($values) : [$values];
 
 		my $first_value = $values -> [0];
 		


### PR DESCRIPTION
Example:

```
    my $filters =  [
            ['(users.label LIKE %?% OR users.comments LIKE %?%)' => ['Joe', 'anchor']]
    ];

    sql ('users(id, fake, hours_from)' => [@$filters]);
    sql ('users(SUM(hours_from))' => [@$filters]);
```

second call ignores filter, because

```
['(table.reason LIKE %?% OR table.label LIKE %?%)' => ['Joe', 'anchor']]
```

becomes

```
['(table.reason LIKE %?% OR table.label LIKE %?%)' => []]
```
