### PR TITLE
нестандартный экран фильтров в диалоге выбора объекта (например, договора)

### DIFF
--- a/Eludia/Presentation/FormFields/multi_select.pm
+++ b/Eludia/Presentation/FormFields/multi_select.pm
@@ -4,6 +4,9 @@ sub draw_form_field_multi_select {
 
 	my ($options, $data) = @_;
 
+	local $_REQUEST {select} = undef
+		if $options -> {href} =~ m/\bmulti_select=1\b/;
+
 	check_href ($options);
 
 	my $label = $options -> {label};


### PR DESCRIPTION
multi_select поле на форме внутри select диалога не работает: дает выбрать только одно значение,
(которое не прописывается в форме)
