### PR TITLE
open_popup_menu: allow to specify custom position

### DIFF
--- a/Eludia/Presentation/Skins/TurboMilk.pm
+++ b/Eludia/Presentation/Skins/TurboMilk.pm
@@ -2930,7 +2930,7 @@ sub draw_table {
 			
 			if (@{$i -> {__types}} && $conf -> {core_hide_row_buttons} > -1 && !$_REQUEST {lpt}) {
 				$menus .= $i -> {__menu};
-				$html  .= qq{ oncontextmenu="open_popup_menu('$i'); blockEvent ();"};
+				$html  .= qq{ oncontextmenu="open_popup_menu(event, '$i'); blockEvent ();"};
 			}
 
 			$html .= '>';

--- a/Eludia/Presentation/Skins/TurboMilk/navigation.js.pm
+++ b/Eludia/Presentation/Skins/TurboMilk/navigation.js.pm
@@ -726,7 +726,7 @@ function menuItemOut () {
 	timer = setTimeout('hideSubMenus(0)',delay);
 }
 
-function open_popup_menu (type, level) {
+function open_popup_menu (event, type, level) {
 
 	clearTimeout(timer);
 
@@ -3497,7 +3497,7 @@ dTree.prototype.node = function(node, nodeId) {
 
 		if (this.config.useStatusText) str += ' onmouseover="window.status=\'' + node.name + '\';return true;" onmouseout="window.status=\'\';return true;" ';
 
-		if (node.context_menu) str += ' oncontextmenu="' + this.obj + '.s(' + nodeId + '); open_popup_menu(\'' + node.context_menu + '\'); blockEvent ();"';
+		if (node.context_menu) str += ' oncontextmenu="' + this.obj + '.s(' + nodeId + '); open_popup_menu(event, \'' + node.context_menu + '\'); blockEvent ();"';
 		
 		if (this.config.useSelection && ((node._hc && this.config.folderLinks) || !node._hc)) str += ' onclick="javascript: ' + this.obj + '.s(' + nodeId + '); "';
 		if (node._hc && node.pid != this.root.id) str += ' onDblClick="' + this.obj + '.o(' + nodeId + '); "';


### PR DESCRIPTION
in order to  implement custom table cell contextmenu

``` perl
                draw_cells ({
                },[
...
{
                        label   => $i -> {base_doc_label},
                        href    => $i -> {base_doc_href},
                        max_len => 80,
                        a_class => $i -> {base_doc_href}? 'tasks-file-link' : undef,
                        attributes => {oncontextmenu => $i -> {base_doc_context_menu_js}},
                    },
```

... results in 

```
<td oncontextmenu = '
                blockEvent();
                var salt = '&salt=' + Math.round(Math.random() * 1000);

                // closure to pass right click coordinates to callback
                var open_menu_if_can_view_doc = (function(pos) {
                    return function (response) {
                        if (!response.is_can_view) {
                            return;
                        }
                        open_popup_menu(pos, '$task', 0);
                    }
                })({'clientX' : event.clientX, 'clientY' : event.clientY});

                \$.getJSON('/?sid=$_REQUEST{sid}&type=$$task{base_doc_table}&id=$$task{id_type}&action=download_rights' + salt,
                    open_menu_if_can_view_doc
                );
'
```

actually this commit is subset of Pavel's upcoming webkit compatibility rewrite
