### PR TITLE
double quotes in filter broke filter button href

### DIFF
--- a/Eludia/Presentation.pm
+++ b/Eludia/Presentation.pm
@@ -416,6 +416,7 @@ sub check_href {
 				next if $k =~ /^_/ && !$_INHERITABLE_PARAMETER_NAMES -> {$k};
 				next if             $_NONINHERITABLE_PARAMETER_NAMES -> {$k};
 				$h {$k} = uri_escape ($_REQUEST {$k});
+				$h {$k} = encode_entities ($_REQUEST {$k}, '"');
 
 			}
 			


### PR DESCRIPTION
when someone enters something like 
ООО "Рога и копыта"
as standart filter (Queries.pm) search string 
href which opens filter screen contains quotes and href
`<a href="... &0_508="&0_509=... "`
does not work
