### PR TITLE
tree: always draw in non-active mode, since active not implemented

### DIFF
--- a/Eludia/Presentation/Skins/Ken.pm
+++ b/Eludia/Presentation/Skins/Ken.pm
@@ -4232,7 +4232,7 @@ sub draw_tree {
                	
 	};
 	
-	if (!$options -> {active}) {
+	if (1) { # !$options -> {active}
 	
 		my %p2n = ();
 		my %i2n = ();


### PR DESCRIPTION
почти везде в коде дереов рисуется с active, ругается на отсутствующий datasource
проще поменять в движке, чем везде выключать active
