### PR TITLE
tree: url_base option support

### DIFF
--- a/Eludia/Presentation/Skins/Ken.pm
+++ b/Eludia/Presentation/Skins/Ken.pm
@@ -4244,7 +4244,7 @@ sub draw_tree {
 			my $nn = {
 				id   => $i -> {id},
 				text => $n -> {name},
-				href => $n -> {url},
+				href => $options -> {url_base} . $n -> {url},
 			};
 		
 			push @{$p2n {0 + $i -> {parent}} ||= []}, $nn;


### PR DESCRIPTION
url_base много уже где используется, в новом скине получаются узлы с неправильной ссылкой
