### PR TITLE
Syntax error, unrecognized expression: img[id^=calendar_trigger_hash(0xaadsa)]

### DIFF
--- a/Eludia/Presentation/Skins/Ken/navigation.js.pm
+++ b/Eludia/Presentation/Skins/Ken/navigation.js.pm
@@ -3297,7 +3297,7 @@ Calendar.setup = function (params) {
 
 	var triggerEl = params.button || params.displayArea || params.inputField;
 
-	$('img[id^=' + triggerEl.id + ']').live (params.eventName, function (event) {
+	$('img[id^=\'' + triggerEl.id + '\']').live (params.eventName, function (event) {
 
 		var dateEl = event.target.previousSibling.previousSibling;
 		var dateFmt = params.inputField ? params.ifFormat : params.daFormat;


### PR DESCRIPTION
jquery обвязки (меню и шапка) - 1.8, движок использует 1.3.4
побеждает обвязка: $().jquery в контексте страницы возвращает '1.8.2'
в ней данный селектор ломается
наверное, будут еще проблемы, пока всплыло только это

наверное, надо вычистить jquery из navigation.js?
